### PR TITLE
Changed the id of Nintendo 3DS: 'n3ds' instead of '3ds'

### DIFF
--- a/PLATFORM_IDs.md
+++ b/PLATFORM_IDs.md
@@ -78,5 +78,4 @@ Platform ID list for GOG Galaxy 2.0 Integrations
 | psp	| Playstation Portable |
 | psvita	| Playstation Vita |
 | nds	| Nintendo DS |
-| 3ds	| Nintendo 3DS |
-
+| n3ds	| Nintendo 3DS |


### PR DESCRIPTION
Every id of Nintendo consoles starts with 'n'. So the 3DS should do too.