### PR TITLE
Add NVIDIA GeForce NOW to the supported platforms

### DIFF
--- a/PLATFORM_IDs.md
+++ b/PLATFORM_IDs.md
@@ -80,3 +80,4 @@ Platform ID list for GOG Galaxy 2.0 Integrations
 | nds	| Nintendo DS |
 | 3ds	| Nintendo 3DS |
 | pathofexile | Path of Exile |
+| geforcenow	| NVIDIA GeForce NOW |

--- a/src/galaxy/api/consts.py
+++ b/src/galaxy/api/consts.py
@@ -81,6 +81,7 @@ class Platform(Enum):
     NintendoDs = "nds"
     Nintendo3Ds = "3ds"
     PathOfExile = "pathofexile"
+    GeForceNow = "geforcenow"
 
 class Feature(Enum):
     """Possible features that can be implemented by an integration.


### PR DESCRIPTION
NVIDIA has a game streaming platform called GeForce NOW (https://www.nvidia.com/en-us/geforce/products/geforce-now/). This PR adds it to the supported platforms enum, so plugins will be able to be written for it.