### PR TITLE
Adding Nintendo Game Boy Color and Nintendo Game Boy Advance to the Platform List

### DIFF
--- a/PLATFORM_IDs.md
+++ b/PLATFORM_IDs.md
@@ -80,3 +80,5 @@ Platform ID list for GOG Galaxy 2.0 Integrations
 | nds	| Nintendo DS |
 | 3ds	| Nintendo 3DS |
 | pathofexile | Path of Exile |
+| ngbc | Nintendo Game Boy Color |
+| ngba | Nintendo Game Boy Advance |

--- a/src/galaxy/api/consts.py
+++ b/src/galaxy/api/consts.py
@@ -90,8 +90,8 @@ class Platform(Enum):
     Playfire = "playfire"
     Oculus = "oculus"
     Test = "test"
-    GameBoyColor = "gbc"
-    GameBoyAdvance = "gba"
+    NintendoGameBoyColor = "ngbc"
+    NintendoGameBoyAdvance = "ngba"
 
 
 class Feature(Enum):

--- a/src/galaxy/api/consts.py
+++ b/src/galaxy/api/consts.py
@@ -90,6 +90,8 @@ class Platform(Enum):
     Playfire = "playfire"
     Oculus = "oculus"
     Test = "test"
+    GameBoyColor = "gbc"
+    GameBoyAdvance = "gba"
 
 
 class Feature(Enum):


### PR DESCRIPTION
Adding the Nintendo Game Boy Color and Game Boy Advance as Platforms since were not on the platform list