### PR TITLE
Reduce error spam on plugin termination

### DIFF
--- a/src/galaxy/api/plugin.py
+++ b/src/galaxy/api/plugin.py
@@ -1129,8 +1129,11 @@ def create_and_run_plugin(plugin_class, argv):
             async with plugin_class(reader, writer, token) as plugin:
                 await plugin.run()
         finally:
-            writer.close()
-            await writer.wait_closed()
+            try:
+                writer.close()
+                await writer.wait_closed()
+            except (ConnectionAbortedError, ConnectionResetError):
+                pass
 
     try:
         if sys.platform == "win32":


### PR DESCRIPTION
There are a lot of error messages connected with connection abort/reset on plugin closing.[1][2]

This PR handles them and hides because we do not care much about connections after plugin shutdown.

[1] https://sentry.friends-of-friends-of-galaxy.org/share/issue/035dd41615c946e4b2e100d528e27043/
[2] https://sentry.friends-of-friends-of-galaxy.org/share/issue/be2ae051198d4f3aa249b54782890e8d/